### PR TITLE
Feature/analytics package v2

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/analytics",
-  "version": "1.0.1-alpha-1",
+  "version": "2.0.0",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "author": "Complex Data Collective <developers@coda.co>",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -11,7 +11,8 @@
     "dev": "npm run build -- --watch"
   },
   "peerDependencies": {
-    "next": "13 || 14"
+    "next": "13 || 14",
+    "@maxmind/geoip2-node": "^5.0.0"
   },
   "devDependencies": {
     "eslint-config-custom": "workspace:*",
@@ -19,7 +20,5 @@
     "tsup": "^7.2.0",
     "typescript": "^5.3.2"
   },
-  "dependencies": {
-    "@maxmind/geoip2-node": "^5.0.0"
-  }
+  "dependencies": {}
 }

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -17,3 +17,20 @@ export function ensureError(value: unknown): Error {
   );
   return error;
 }
+
+export function getBaseUrl() {
+  if (typeof window !== "undefined")
+    // browser should use relative path
+    return "";
+
+  if (process.env.VERCEL_URL)
+    // reference for vercel.com
+    return `https://${process.env.VERCEL_URL}`;
+
+  if (process.env.NEXT_PUBLIC_URL)
+    // Manually set deployment URL from env
+    return process.env.NEXT_PUBLIC_URL;
+
+  // assume localhost
+  return `http://127.0.0.1:3000`;
+}


### PR DESCRIPTION
Implemented a smaller API surface for createRouteHandler and
makeEventTracker:

createRouteHandler:
  - Removed maxmind environment variable parameters.
  - Removed webclient parameter.
  - Added maxMindClient parameter. The client is now constructed in the
    route handler, and then passed in as a full instance.

makeEventTracker:
  - Made endpoint optional, and changed the structure from an object
    to a plain string
  - Made the endpoint default to `/api/analytics` if not provided.
  - Added a `getBaseUrl` function so that the consumer doesn't have to
    calculate the base URL themselves.

Also added better error responses to handle 404 and 500 errors.

Also moved maxMind to a peer dependency, so that consuming packages can explicitly handle the versioning.

These are breaking changes that required bumping the package to v2.